### PR TITLE
Add Statsd plugin for monitoring satellite data

### DIFF
--- a/ansible/monitoring-plugins.yaml
+++ b/ansible/monitoring-plugins.yaml
@@ -1,0 +1,11 @@
+---
+# Build and upload the grafana template for the server
+
+- hosts: satellite6
+  remote_user: root
+  gather_facts: false
+  vars_files:
+    - ../conf/satmon.yaml
+  roles:
+    - monitoring-plugins
+...

--- a/ansible/roles/monitoring-plugins/files/satellite-reporter.service
+++ b/ansible/roles/monitoring-plugins/files/satellite-reporter.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Satellite 6 Metric Collection Service
+After=collectd.service
+
+[Service]
+ExecStart=/root/satellite_venv/bin/python /usr/bin/satellite_stats.py
+StandardOutput=null
+
+[Install]
+WantedBy=multi-user.target
+Alias=satellite-reporter.service

--- a/ansible/roles/monitoring-plugins/files/satellite_stats.py
+++ b/ansible/roles/monitoring-plugins/files/satellite_stats.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+'''
+File: satellite_stats.py
+Description: Satellite Stats collection service
+Author: Saurabh Badhwar <sbadhwar@redhat.com>
+Date: 24/04/2017
+'''
+from statsd_plugin.StatsdPlugin import StatsdPlugin
+import subprocess
+
+class Satellite6(StatsdPlugin):
+    '''
+    Collects different metrics related to Satellite 6
+    The collected metrics include:
+     - Passenger Requests in Top Level Queue
+     - Postgres Opened Files
+    '''
+
+    def satellite6_passenger_requests(self):
+        '''
+        Collect the number of requests in top-level queue in passenger
+        Params: None
+        Returns: None
+        '''
+
+        process_data = subprocess.check_output(['passenger-status']).split('\n')
+
+        for field in process_data:
+            if "Requests in top-level queue" in field:
+                requests = field.split(':')[1].strip()
+        self.store_results('passenger_requests_top_level_queue', requests)
+
+    def satellite6_passenger_processes(self):
+        '''
+        Collect the number of processes inside passenger
+        Params: None
+        Returns: None
+        '''
+
+        process_data = subprocess.check_output(['passenger-status']).split('\n')
+
+        for field in process_data:
+            if "Processes" in field:
+                processes = field.split(':')[1].strip()
+        self.store_results('passenger_running_processes', processes)
+
+if __name__ == '__main__':
+    try:
+        sat6_plugin = Satellite6()
+        sat6_plugin.start()
+    except Exception, e:
+        print str(e)
+        sat6_plugin.stop()

--- a/ansible/roles/monitoring-plugins/files/satellite_stats.py
+++ b/ansible/roles/monitoring-plugins/files/satellite_stats.py
@@ -6,6 +6,7 @@ Author: Saurabh Badhwar <sbadhwar@redhat.com>
 Date: 24/04/2017
 '''
 from statsd_plugin.StatsdPlugin import StatsdPlugin
+import os
 import subprocess
 
 class Satellite6(StatsdPlugin):
@@ -43,6 +44,16 @@ class Satellite6(StatsdPlugin):
             if "Processes" in field:
                 processes = field.split(':')[1].strip()
         self.store_results('passenger_running_processes', processes)
+
+    def satellite6_postgres_locks(self):
+        '''
+        Collects the metrics about how many locks are being held by postgres
+        Params: None
+        Returns: None
+        '''
+
+        process_data = subprocess.check_output('lsof | grep "postgres" | wc -l', shell=True).split('\n')[0]
+        self.store_results('postgres_locks_held', int(process_data))
 
 if __name__ == '__main__':
     try:

--- a/ansible/roles/monitoring-plugins/tasks/main.yaml
+++ b/ansible/roles/monitoring-plugins/tasks/main.yaml
@@ -1,0 +1,32 @@
+---
+- name: Install statsd
+  pip:
+    name: statsd
+    virtualenv: /root/satellite_venv
+
+- name: Install the required packages to run stats collection
+  pip:
+    name: statsd-plugin
+    virtualenv: /root/satellite_venv
+
+- name: Deploy statistics collection service
+  copy:
+    src: satellite_stats.py
+    dest: /usr/bin/satellite_stats.py
+
+- name: Deploy SystemD service
+  copy:
+    src: satellite-reporter.service
+    dest: /usr/lib/systemd/system/satellite-reporter.service
+
+- name: Confirm if collectd is running
+  service:
+    name: collectd
+    state: running
+    enabled: yes
+
+- name: Start the Satellite monitoring service
+  service:
+    name: satellite-reporter
+    state: started
+    enabled: yes


### PR DESCRIPTION
The PR makes the following changes:
- Add a statsd based service to gather satellite metrics
- Builds a systemd service so as to start the service on system boot
- Adds ansible playbook for installing and configuring the service
Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>