### PR TITLE
Prepare collectd for ELK stack integration

### DIFF
--- a/ansible/roles/collectd-generic/templates/satellite6.collectd.conf.j2
+++ b/ansible/roles/collectd-generic/templates/satellite6.collectd.conf.j2
@@ -22,6 +22,7 @@ LoadPlugin interface
 LoadPlugin irq
 LoadPlugin load
 LoadPlugin memory
+LoadPlugin network
 LoadPlugin numa
 LoadPlugin processes
 LoadPlugin postgresql
@@ -38,6 +39,21 @@ LoadPlugin uptime
   SocketPerms "0770"
   DeleteSocket true
 </Plugin>
+
+{% if collectd_network_interface is defined %}
+#Configure the network interface to use
+<Plugin interface>
+  Interface "{{ collectd_network_interface }}"
+  IgnoreSelected false
+</Plugin>
+{% endif %}
+
+{% if collectd_remote_server is defined %}
+#Configure where should collectd send its data
+<Plugin network>
+  Server "{{ collectd_remote_server }}" "{{ collectd_remote_port }}"
+</Plugin>
+{% endif %}
 
 LoadPlugin apache
 <Plugin apache>


### PR DESCRIPTION
For ELK stack to work, collectd needs to send its data to the remote logstash instance

The PR configures this behavior of sending the data to logstash instance when a certain set of dependencies are met in the configuration file

Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>