### PR TITLE
Remove the graphite role from collectd-generic playbook

### DIFF
--- a/ansible/collectd-generic.yaml
+++ b/ansible/collectd-generic.yaml
@@ -7,17 +7,6 @@
 # ansible-playbook --private-key conf/id_rsa -i conf/hosts.ini playbooks/monitoring/collectd-generic.yaml --tags="capsules"
 # ansible-playbook --private-key conf/id_rsa -i conf/hosts.ini playbooks/monitoring/collectd-generic.yaml --tags="docker-hosts"
 # ansible-playbook --private-key conf/id_rsa -i conf/hosts.ini playbooks/monitoring/collectd-generic.yaml --tags="satellite6,capsules"
-
-- hosts: graphite
-  remote_user: root
-  vars:
-    config_type: graphite
-  vars_files:
-    - ../conf/satmon.yaml
-  roles:
-    - collectd-generic
-  tags: graphite
-
 - hosts: satellite6
   remote_user: root
   vars:


### PR DESCRIPTION
We don't need the graphite role in collectd generic playbook because of the decoupling that is there