### PR TITLE
Correct Dashboard link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ OR
 
 ### To view your Dashboard visit:
 
-http://<monitoring server>:11202
+http://\<monitoring server>:11202


### PR DESCRIPTION
I guess you forgot to use " \\" before \<monitoring server> due to which it was not visible in readme.md.